### PR TITLE
moves `debug` from devDependencies to dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -260,7 +260,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
       "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -1046,8 +1045,7 @@
     "ms": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-      "dev": true
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg=="
     },
     "mute-stream": {
       "version": "0.0.7",

--- a/package.json
+++ b/package.json
@@ -12,13 +12,13 @@
   "author": "Debitoor",
   "license": "ISC",
   "dependencies": {
-    "node-fetch": "2.3.0"
+    "node-fetch": "2.3.0",
+    "debug": "4.1.1"
   },
   "devDependencies": {
     "@debitoor/eslint-config-debitoor": "3.0.1",
     "@debitoor/mocha-strict-dependencies": "1.1.0",
     "@types/node": "11.10.5",
-    "debug": "4.1.1",
     "eslint": "5.15.0",
     "mocha": "6.1.4",
     "mocha-eslint": "5.0.0"


### PR DESCRIPTION
This should resolve issues where `debug` was otherwise not found as a dependency